### PR TITLE
Client library errors out when called from within the react app

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -154,9 +154,9 @@
       }
     },
     "@open-rights-exchange/orejs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@open-rights-exchange/orejs/-/orejs-1.2.0.tgz",
-      "integrity": "sha512-Jvy4/KWIzSvUjwE1nzeTuVXJfFZF9CD2/PJ4NsrU3Q3FpUGSAOvVBQk8nACo2XfS6eYgAO9VXTKEzzQdECJJMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@open-rights-exchange/orejs/-/orejs-1.2.1.tgz",
+      "integrity": "sha512-D7S9oOehmVmezbG9rFumRRSn1xJnxDPNe9ywF5KNRz/RXdn4b8Di1w7T/L1+yb2pG8SIA/UNmAWAKHbMPsM+qw==",
       "requires": {
         "bignumber.js": "^7.2.1",
         "dotenv": "^6.1.0",
@@ -891,6 +891,7 @@
         "babel-plugin-transform-regenerator": "^6.22.0",
         "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-es2015": {
@@ -1287,9 +1288,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000898",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000898.tgz",
-      "integrity": "sha512-ytlTZqO4hYe4rNAJhMynUAIUI33jsP2Bb1two/9OVC39wZjPZ8exIO0eCLw5mqAtegOGiGF0kkTWTn3B02L+mw==",
+      "version": "1.0.30000903",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000903.tgz",
+      "integrity": "sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g==",
       "dev": true
     },
     "chalk": {
@@ -1621,9 +1622,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.81",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.81.tgz",
-      "integrity": "sha512-+rym2xtzwPWmoi8AYRrCdW65QOT0vfUHjZb5mjgh0VLyj31pGM3CpP3znKhQNBzQaWujR/KEl/mfC2lnKYgADA==",
+      "version": "1.3.83",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz",
+      "integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA==",
       "dev": true
     },
     "encodeurl": {
@@ -3921,7 +3922,7 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
@@ -4010,7 +4011,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -894,6 +894,38 @@
         "semver": "^5.3.0"
       }
     },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
+      }
+    },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -891,7 +891,6 @@
         "babel-plugin-transform-regenerator": "^6.22.0",
         "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
-        "semver": "^5.3.0"
       }
     },
     "babel-preset-es2015": {

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,6 @@
     "jsonwebtoken": "^8.3.0",
     "morgan": "^1.9.0",
     "node-fetch": "^2.1.2",
-    "semver": "^5.6.0",
     "sort-json": "^2.0.0",
     "tslint": "^5.9.1",
     "typescript": "^2.8.1",

--- a/client/package.json
+++ b/client/package.json
@@ -7,8 +7,9 @@
   "description": "Client library for api.market",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "babel . --ignore node_modules,dist --out-dir dist && npm run copyfiles",
+    "build": "babel . --ignore node_modules,dist --out-dir dist && npm run copyfiles && npm run copypackagejson",
     "copyfiles": "cp ./example/apimarket_config.example.json ./example/package.json ./dist/example/",
+    "copypackagejson": "cp ./package.json ./dist/",
     "example:client": "node --trace-warnings ./dist/example/client/index.js",
     "prepublish": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -46,6 +47,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.0",
     "babel-cli": "^6.26.0",
-    "babel-preset-env": "^1.7.0"
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-es2015": "^6.24.1"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "@apimarket/apimarket",
   "version": "1.0.1",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=7.6.0"
   },
   "description": "Client library for api.market",
   "main": "./dist/index.js",
@@ -47,6 +47,7 @@
     "@babel/core": "^7.1.0",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "babel-preset-es2015": "^6.24.1"
+    "babel-preset-es2015": "^6.24.1",
+    "semver": "^5.6.0"
   }
 }

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -11,10 +11,11 @@ const semver = require('semver');
 const engines = require('../package').engines;
 const version = engines.node;
 
-if (!semver.satisfies(process.version, version)) {
-  throw new Error(`Required node version ${version} not satisfied with current version ${process.version}.`);
+if (process.version.length != 0) {
+  if (!semver.satisfies(process.version, version)) {
+    throw new Error(`Required node version ${version} not satisfied with current version ${process.version}.`);
+  }
 }
-
 const VOUCHER_CATEGORY = "apimarket.apiVoucher"
 const uuidv1 = require('uuid/v1');
 
@@ -40,20 +41,10 @@ class ApiMarketClient {
       verifierAccountName,
       verifierAuthKey
     } = config
+
     var errorMessage = ''
 
-    //decode verifierAuthKey
-    try {
-      config.verifierAuthKey = Base64.decode(verifierAuthKey)
-    } catch (error) {
-      let errMsg = `decode error: ${error.message}`
-      if (error.message == 'Non-base58 character') {
-        errMsg = `Problem decoding the verifierAuthKey. Make sure to download the correct config file from api.market.`
-      }
-      throw new Error(`${errMsg} ${error}`)
-    }
-
-    if (config.verifierAuthKey.length == 0) {
+    if (!verifierAuthKey) {
       errorMessage += `\n --> VerifierAuthKey is missing or invalid. Download the API's config file from api.market.`
     }
 
@@ -68,6 +59,18 @@ class ApiMarketClient {
 
     if (errorMessage != '') {
       throw new Error(`Config file (e.g., apimarket_config.json) is missing or has bad values. ${errorMessage}`)
+    }
+
+    //decode verifierAuthKey
+    try {
+      config.verifierAuthKey = Base64.decode(verifierAuthKey)
+    } catch (error) {
+
+      let errMsg = `decode error: ${error.message}`
+      if (error.message == 'Non-base58 character') {
+        errMsg = `Problem decoding the verifierAuthKey. Make sure to download the correct config file from api.market.`
+      }
+      throw new Error(`${errMsg} ${error}`)
     }
 
     this.config = config
@@ -293,9 +296,7 @@ class ApiMarketClient {
         url,
         options
       } = await this.getOptions(endpoint, httpMethod, oreAccessToken, requestParameters)
-
       const response = await fetch(url, options)
-
       if (response.headers.get('content-type').includes("application/json")) {
         return response.json()
       } else {

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -3,19 +3,14 @@ const fetch = require('node-fetch')
 const Base64 = require('js-base64').Base64;
 const ecc = require('eosjs-ecc')
 const hash = require('hash.js')
+var URL = require('url').URL
 const {
   Orejs,
   crypto
 } = require('@open-rights-exchange/orejs')
-const semver = require('semver');
 const engines = require('../package').engines;
 const version = engines.node;
 
-if (process.version.length != 0) {
-  if (!semver.satisfies(process.version, version)) {
-    throw new Error(`Required node version ${version} not satisfied with current version ${process.version}.`);
-  }
-}
 const VOUCHER_CATEGORY = "apimarket.apiVoucher"
 const uuidv1 = require('uuid/v1');
 

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -3,6 +3,7 @@ const fetch = require('node-fetch')
 const Base64 = require('js-base64').Base64;
 const ecc = require('eosjs-ecc')
 const hash = require('hash.js')
+const semver = require('semver');
 var URL = require('url').URL
 const {
   Orejs,
@@ -10,6 +11,13 @@ const {
 } = require('@open-rights-exchange/orejs')
 const engines = require('../package').engines;
 const version = engines.node;
+
+// check node version when running the client within a node application
+if (process.version.length != 0) {
+  if (!semver.satisfies(process.version, version)) {
+    throw new Error(`Required node version ${version} not satisfied with current version ${process.version}.`);
+  }
+}
 
 const VOUCHER_CATEGORY = "apimarket.apiVoucher"
 const uuidv1 = require('uuid/v1');


### PR DESCRIPTION
- The library should now work with node versions supporting ES6 (>7.6)
- correct error handling
- checks node version only while running the client library within a node application